### PR TITLE
Clean gutenberg license boilerplate

### DIFF
--- a/blueprints/generate_domain_names.py
+++ b/blueprints/generate_domain_names.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 import json
 from flask import Blueprint, request, jsonify
+from gutenberg_cleaner import simple_cleaner
 import public_domains
 
 generate_domain_names_blueprint = Blueprint('generate_domain_names_blueprint', __name__)
@@ -22,7 +23,7 @@ def generate_domain_names():
             print("downloading book file...")
             with open(book_text_file_path, "w") as book_text_file:
                 if (book_text):
-                    book_text_file.write(book_text)
+                    book_text_file.write(simple_cleaner(book_text))
 
         print("generating hosts...")
         hosts = public_domains.get_hosts(book_text_file_path, quiet=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Flask==2.2.5
-Flask_Caching==2.1.0
-public_domains==0.0.6
+Flask>=2.2.5
+Flask-Caching>=2.1.0
+public_domains>=0.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask>=2.2.5
 Flask-Caching>=2.1.0
 public_domains>=0.0.8
+gutenberg-cleaner


### PR DESCRIPTION
Project Gutenberg files have substantial boiler plate licenses that are getting included and creating domains like  license.please.read  and  creating.derivative.works 

This PR pipes the text through the gutenberg_cleaner module first to remove extraneous text